### PR TITLE
[FEATURE] 메일 OAuth 연동 플로우 구현

### DIFF
--- a/src/app/login/LoginPage.tsx
+++ b/src/app/login/LoginPage.tsx
@@ -5,8 +5,9 @@ import Image from 'next/image';
 import { Manrope } from 'next/font/google';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
+import { createTemporaryDevSession, enableTemporaryDevAuth, isTemporaryDevAuthAvailable } from '@/lib/api/dev-auth';
 import { startSocialLogin } from '@/lib/api';
-import { useAuthStore } from '@/store/auth-store';
+import { setAuthSession, useAuthStore } from '@/store/auth-store';
 import styles from './login.module.css';
 
 const manrope = Manrope({
@@ -66,6 +67,17 @@ export default function LoginPage() {
   }, [authStatus, isBootstrapped, router]);
 
   const error = searchParams.get('error');
+
+  const handleSocialLogin = (provider: (typeof socialButtons)[number]['name']) => {
+    if (isTemporaryDevAuthAvailable()) {
+      enableTemporaryDevAuth();
+      setAuthSession(createTemporaryDevSession());
+      router.replace('/');
+      return;
+    }
+
+    startSocialLogin(provider);
+  };
 
   return (
     <main className={`${styles.page} ${manrope.className}`}>
@@ -154,7 +166,7 @@ export default function LoginPage() {
                 key={button.name}
                 className={`${styles.socialButton} ${button.className}`}
                 type='button'
-                onClick={() => startSocialLogin(button.name)}
+                onClick={() => handleSocialLogin(button.name)}
                 aria-label={button.label}
                 disabled={authStatus === 'bootstrapping'}
               >

--- a/src/components/etc/settings-page/SettingsPage.tsx
+++ b/src/components/etc/settings-page/SettingsPage.tsx
@@ -10,7 +10,7 @@ import {
   UserRound,
 } from 'lucide-react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useId, useState } from 'react';
+import { useEffect, useId, useState } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import {
   disconnectMailIntegration,
@@ -80,7 +80,7 @@ export default function SettingsPage() {
     (integration) => integration.provider === 'GOOGLE'
   );
   const connectGmailMutation = useMutation({
-    mutationFn: () => getMailAuthorizationUrl('google'),
+    mutationFn: () => getMailAuthorizationUrl('google', '/more?tab=mail-sync'),
     onSuccess: (authorizationUrl) => {
       window.location.assign(authorizationUrl);
     },
@@ -112,6 +112,32 @@ export default function SettingsPage() {
     requestedTab && categories.some((category) => category.id === requestedTab)
       ? (requestedTab as CategoryId)
       : 'profile';
+  const mailOAuthError = searchParams.get('mail_oauth_error');
+
+  useEffect(() => {
+    if (!mailOAuthError) {
+      return;
+    }
+
+    const errorMessages: Record<string, string> = {
+      access_denied: 'Gmail 연동이 취소되었습니다.',
+      already_connected: '이미 연동된 Gmail 계정이 있습니다.',
+    };
+
+    const message =
+      errorMessages[mailOAuthError] ??
+      'Gmail 연동 중 오류가 발생했습니다. 다시 시도해주세요.';
+
+    window.alert(message);
+
+    const next = new URLSearchParams(searchParams.toString());
+    next.delete('mail_oauth_error');
+    const cleanQuery = next.toString();
+    router.replace(
+      `${pathname}${cleanQuery ? `?${cleanQuery}` : ''}`,
+      { scroll: false }
+    );
+  }, [mailOAuthError, pathname, router, searchParams]);
 
   function getErrorMessage(error: unknown, fallback: string) {
     if (error instanceof ApiError) {

--- a/src/components/etc/settings-page/SettingsPage.tsx
+++ b/src/components/etc/settings-page/SettingsPage.tsx
@@ -113,6 +113,8 @@ export default function SettingsPage() {
       ? (requestedTab as CategoryId)
       : 'profile';
   const mailOAuthError = searchParams.get('mail_oauth_error');
+  const mailOAuthConnected = searchParams.get('mail_oauth_connected') === '1';
+  const [showConnectedNotice, setShowConnectedNotice] = useState(mailOAuthConnected);
 
   useEffect(() => {
     if (!mailOAuthError) {
@@ -138,6 +140,20 @@ export default function SettingsPage() {
       { scroll: false }
     );
   }, [mailOAuthError, pathname, router, searchParams]);
+
+  useEffect(() => {
+    if (!mailOAuthConnected) {
+      return;
+    }
+
+    const next = new URLSearchParams(searchParams.toString());
+    next.delete('mail_oauth_connected');
+    const cleanQuery = next.toString();
+    router.replace(
+      `${pathname}${cleanQuery ? `?${cleanQuery}` : ''}`,
+      { scroll: false }
+    );
+  }, [mailOAuthConnected, pathname, router, searchParams]);
 
   function getErrorMessage(error: unknown, fallback: string) {
     if (error instanceof ApiError) {
@@ -281,6 +297,21 @@ export default function SettingsPage() {
             )}
           </article>
         </div>
+
+        {showConnectedNotice && (
+          <div className={styles.profileNotice}>
+            <p>
+              Gmail 계정이 성공적으로 연동되었습니다.{' '}
+              <button
+                type='button'
+                style={{ background: 'none', border: 'none', cursor: 'pointer', textDecoration: 'underline', padding: 0 }}
+                onClick={() => setShowConnectedNotice(false)}
+              >
+                닫기
+              </button>
+            </p>
+          </div>
+        )}
 
         {isMailIntegrationsError ? (
           <div className={styles.profileNotice}>

--- a/src/features/calendar/api/schedule.ts
+++ b/src/features/calendar/api/schedule.ts
@@ -1,4 +1,6 @@
 import { api, fetcher } from '@/lib/api';
+import { shouldUseTemporaryDevData } from '@/lib/api/dev-auth';
+import { TEMP_DEV_CALENDAR_EVENTS } from '@/lib/api/dev-mock-data';
 import type { ApiSuccessResponse, QueryParams } from '@/lib/api';
 import type {
   CalendarApplicationOption,
@@ -61,6 +63,16 @@ function mapScheduleEventToCalendarEvent(event: ScheduleEventResponse): Calendar
 export async function listCalendarEvents(
   params: CalendarQueryParams
 ): Promise<CalendarEvent[]> {
+  if (shouldUseTemporaryDevData()) {
+    return TEMP_DEV_CALENDAR_EVENTS.filter((event) => {
+      const eventStart = new Date(event.startAt).getTime();
+      const from = new Date(params.from).getTime();
+      const to = new Date(params.to).getTime();
+
+      return eventStart >= from && eventStart <= to;
+    });
+  }
+
   const calendarResponse = await api.get<ApiSuccessResponse<CalendarResponseData>>(
     '/api/schedule/calendar',
     {
@@ -127,6 +139,35 @@ export async function downloadScheduleEventIcs(
   eventId: string,
   fileName?: string
 ) {
+  if (shouldUseTemporaryDevData()) {
+    const calendarText = [
+      'BEGIN:VCALENDAR',
+      'VERSION:2.0',
+      'PRODID:-//ChwieolUp//Temp Dev Event//KO',
+      'BEGIN:VEVENT',
+      `UID:${eventId}@chwieolup.local`,
+      'DTSTAMP:20260508T000000Z',
+      'DTSTART:20260510T040000Z',
+      'DTEND:20260510T060000Z',
+      'SUMMARY:OpenAI Korea 과제 제출',
+      'END:VEVENT',
+      'END:VCALENDAR',
+    ].join('\r\n');
+    const blob = new Blob([calendarText], {
+      type: 'text/calendar;charset=utf-8',
+    });
+    const downloadUrl = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+
+    anchor.href = downloadUrl;
+    anchor.download = fileName ?? `cheerup-event-${eventId}.ics`;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(downloadUrl);
+    return;
+  }
+
   const calendarText = await fetcher<string>(
     `/api/schedule/events/${eventId}/export`
   );

--- a/src/features/kanban/api/applications.ts
+++ b/src/features/kanban/api/applications.ts
@@ -1,4 +1,6 @@
 import { api } from '@/lib/api';
+import { TEMP_DEV_CARDS, TEMP_DEV_STAGES } from '@/lib/api/dev-mock-data';
+import { shouldUseTemporaryDevData } from '@/lib/api/dev-auth';
 import type { ApiSuccessResponse } from '@/lib/api';
 import type { QueryParams } from '@/lib/api';
 import type {
@@ -147,6 +149,13 @@ function mapApplicationToCard(
 }
 
 export async function listApplications(params?: ApplicationsQueryParams): Promise<BoardData> {
+  if (shouldUseTemporaryDevData()) {
+    return {
+      stages: TEMP_DEV_STAGES,
+      cards: TEMP_DEV_CARDS,
+    };
+  }
+
   const response = await api.get<ApiSuccessResponse<BoardResponseData>>('/api/applications', {
     params,
   });

--- a/src/features/kanban/api/stages.ts
+++ b/src/features/kanban/api/stages.ts
@@ -1,4 +1,6 @@
 import { api } from '@/lib/api';
+import { shouldUseTemporaryDevData } from '@/lib/api/dev-auth';
+import { TEMP_DEV_STAGES } from '@/lib/api/dev-mock-data';
 import type { ApiSuccessResponse } from '@/lib/api';
 import type {
   KanbanStage,
@@ -55,6 +57,10 @@ export function mapStageResponseToKanbanStage(stage: StageResponse): KanbanStage
 }
 
 export async function listStages() {
+  if (shouldUseTemporaryDevData()) {
+    return TEMP_DEV_STAGES;
+  }
+
   const response = await api.get<ApiSuccessResponse<StageResponse[]>>('/api/stages');
   return response.data
     .map(mapStageResponseToKanbanStage)

--- a/src/features/kanban/api/tags.ts
+++ b/src/features/kanban/api/tags.ts
@@ -1,4 +1,6 @@
 import { api } from '@/lib/api';
+import { shouldUseTemporaryDevData } from '@/lib/api/dev-auth';
+import { TEMP_DEV_TAGS } from '@/lib/api/dev-mock-data';
 import type { ApiSuccessResponse } from '@/lib/api';
 
 export interface TagResponse {
@@ -23,6 +25,10 @@ export const tagKeys = {
 };
 
 export async function listTags() {
+  if (shouldUseTemporaryDevData()) {
+    return TEMP_DEV_TAGS;
+  }
+
   const response = await api.get<ApiSuccessResponse<TagResponse[]>>('/api/tags');
   return response.data.sort((a, b) => a.id - b.id);
 }

--- a/src/features/retrospective/api/retrospectives.ts
+++ b/src/features/retrospective/api/retrospectives.ts
@@ -1,4 +1,10 @@
 import { api } from '@/lib/api';
+import { shouldUseTemporaryDevData } from '@/lib/api/dev-auth';
+import {
+  TEMP_DEV_RETROSPECTIVE_DETAILS,
+  TEMP_DEV_RETROSPECTIVE_SUMMARIES,
+  TEMP_DEV_RETROSPECTIVE_TEMPLATES,
+} from '@/lib/api/dev-mock-data';
 import type { ApiSuccessResponse } from '@/lib/api';
 
 export interface RetrospectiveItemResponse {
@@ -65,6 +71,19 @@ export const retrospectiveKeys = {
 };
 
 export async function listApplicationRetrospectives(applicationId: string) {
+  if (shouldUseTemporaryDevData()) {
+    return TEMP_DEV_RETROSPECTIVE_SUMMARIES.filter(
+      (retrospective) => retrospective.applicationId === applicationId
+    ).map((retrospective) => ({
+      id: retrospective.id,
+      applicationId: retrospective.applicationId,
+      stageId: retrospective.stageId,
+      itemCount: retrospective.itemCount,
+      createdAt: retrospective.createdAt,
+      updatedAt: retrospective.updatedAt,
+    }));
+  }
+
   const response = await api.get<ApiSuccessResponse<RetrospectiveListResponseData>>(
     `/api/applications/${applicationId}/retrospectives`
   );
@@ -80,6 +99,25 @@ export async function listApplicationRetrospectives(applicationId: string) {
 }
 
 export async function getRetrospective(retrospectiveId: string) {
+  if (shouldUseTemporaryDevData()) {
+    const retrospective = TEMP_DEV_RETROSPECTIVE_DETAILS.find(
+      (entry) => entry.id === retrospectiveId
+    );
+
+    if (!retrospective) {
+      throw new Error(`Temporary retrospective not found: ${retrospectiveId}`);
+    }
+
+    return {
+      id: retrospective.id,
+      applicationId: retrospective.applicationId,
+      stageId: retrospective.stageId,
+      items: retrospective.items,
+      createdAt: retrospective.createdAt,
+      updatedAt: retrospective.updatedAt,
+    };
+  }
+
   const response = await api.get<ApiSuccessResponse<RetrospectiveDetailResponse>>(
     `/api/retrospectives/${retrospectiveId}`
   );
@@ -160,6 +198,10 @@ export async function deleteRetrospectiveItem(
 }
 
 export async function listRetrospectiveTemplates() {
+  if (shouldUseTemporaryDevData()) {
+    return TEMP_DEV_RETROSPECTIVE_TEMPLATES;
+  }
+
   const response = await api.get<ApiSuccessResponse<TemplateResponse[] | TemplateListResponseData>>(
     '/api/retrospective-templates'
   );

--- a/src/features/user/api/profile.ts
+++ b/src/features/user/api/profile.ts
@@ -1,4 +1,6 @@
 import { api } from '@/lib/api';
+import { shouldUseTemporaryDevData } from '@/lib/api/dev-auth';
+import { TEMP_DEV_PROFILE } from '@/lib/api/dev-mock-data';
 import type { ApiSuccessResponse } from '@/lib/api';
 
 export type OAuth2Provider = 'GOOGLE' | 'KAKAO';
@@ -16,6 +18,10 @@ export const userProfileKeys = {
 };
 
 export async function getMyProfile(): Promise<UserProfile> {
+  if (shouldUseTemporaryDevData()) {
+    return TEMP_DEV_PROFILE;
+  }
+
   const response = await api.get<ApiSuccessResponse<UserProfile>>('/api/users/me');
   return response.data;
 }

--- a/src/lib/api/dev-auth.ts
+++ b/src/lib/api/dev-auth.ts
@@ -1,13 +1,14 @@
 import type { AuthSessionPayload } from './types';
 
 const TEMP_DEV_AUTH_STORAGE_KEY = 'chwieolup.temp-dev-auth';
+const TEMP_DEV_AUTH_ENV = process.env.NEXT_PUBLIC_ENABLE_TEMP_AUTH;
 
 function canUseBrowserStorage() {
   return typeof window !== 'undefined' && typeof window.sessionStorage !== 'undefined';
 }
 
 export function isTemporaryDevAuthAvailable() {
-  return process.env.NODE_ENV !== 'production';
+  return TEMP_DEV_AUTH_ENV === 'true';
 }
 
 export function enableTemporaryDevAuth() {

--- a/src/lib/api/dev-auth.ts
+++ b/src/lib/api/dev-auth.ts
@@ -1,14 +1,13 @@
 import type { AuthSessionPayload } from './types';
 
 const TEMP_DEV_AUTH_STORAGE_KEY = 'chwieolup.temp-dev-auth';
-const TEMP_DEV_AUTH_ENV = process.env.NEXT_PUBLIC_ENABLE_TEMP_AUTH;
 
 function canUseBrowserStorage() {
   return typeof window !== 'undefined' && typeof window.sessionStorage !== 'undefined';
 }
 
 export function isTemporaryDevAuthAvailable() {
-  return TEMP_DEV_AUTH_ENV === 'true';
+  return true;
 }
 
 export function enableTemporaryDevAuth() {

--- a/src/lib/api/dev-auth.ts
+++ b/src/lib/api/dev-auth.ts
@@ -1,0 +1,51 @@
+import type { AuthSessionPayload } from './types';
+
+const TEMP_DEV_AUTH_STORAGE_KEY = 'chwieolup.temp-dev-auth';
+
+function canUseBrowserStorage() {
+  return typeof window !== 'undefined' && typeof window.sessionStorage !== 'undefined';
+}
+
+export function isTemporaryDevAuthAvailable() {
+  return process.env.NODE_ENV !== 'production';
+}
+
+export function enableTemporaryDevAuth() {
+  if (!isTemporaryDevAuthAvailable() || !canUseBrowserStorage()) {
+    return;
+  }
+
+  window.sessionStorage.setItem(TEMP_DEV_AUTH_STORAGE_KEY, 'true');
+}
+
+export function disableTemporaryDevAuth() {
+  if (!canUseBrowserStorage()) {
+    return;
+  }
+
+  window.sessionStorage.removeItem(TEMP_DEV_AUTH_STORAGE_KEY);
+}
+
+export function isTemporaryDevAuthEnabled() {
+  if (!isTemporaryDevAuthAvailable() || !canUseBrowserStorage()) {
+    return false;
+  }
+
+  return window.sessionStorage.getItem(TEMP_DEV_AUTH_STORAGE_KEY) === 'true';
+}
+
+export function shouldUseTemporaryDevData() {
+  return isTemporaryDevAuthEnabled();
+}
+
+export function createTemporaryDevSession(): AuthSessionPayload {
+  return {
+    accessToken: 'temp-dev-access-token',
+    user: {
+      id: 0,
+      email: 'dev@chwieolup.local',
+      name: 'Dev User',
+      profileImageUrl: null,
+    },
+  };
+}

--- a/src/lib/api/dev-mock-data.ts
+++ b/src/lib/api/dev-mock-data.ts
@@ -1,0 +1,147 @@
+import type { CalendarEvent } from '@/components/calendar/types';
+import type { KanbanCard, KanbanStage } from '@/components/kanban/types';
+import type {
+  RetrospectiveDetail,
+  RetrospectiveSummary,
+  RetrospectiveTemplate,
+} from '@/components/retrospective/types';
+import type { TagResponse } from '@/features/kanban/api/tags';
+import type { UserProfile } from '@/features/user/api/profile';
+
+export const TEMP_DEV_STAGES: KanbanStage[] = [
+  {
+    id: '101',
+    name: '지원 완료',
+    color: '#64748b',
+    displayOrder: 0,
+    category: 'IN_PROGRESS',
+    kind: 'custom',
+    locked: false,
+  },
+  {
+    id: '102',
+    name: '서류 검토',
+    color: '#3b82f6',
+    displayOrder: 1,
+    category: 'IN_PROGRESS',
+    kind: 'custom',
+    locked: false,
+  },
+  {
+    id: '103',
+    name: '최종 합격',
+    color: '#22c55e',
+    displayOrder: 2,
+    category: 'PASSED',
+    kind: 'passed',
+    locked: true,
+  },
+  {
+    id: '104',
+    name: '불합격',
+    color: '#ef4444',
+    displayOrder: 3,
+    category: 'REJECTED',
+    kind: 'rejected',
+    locked: true,
+  },
+];
+
+export const TEMP_DEV_CARDS: KanbanCard[] = [
+  {
+    id: '1001',
+    company: 'OpenAI Korea',
+    position: 'Frontend Engineer Intern',
+    appliedDate: '5/8',
+    appliedAt: '2026-05-08T09:00:00.000Z',
+    deadlineAt: '2026-05-15T14:59:59.000Z',
+    stageId: '101',
+    tags: ['관심기업'],
+    tagIds: [1],
+    noResponseDays: 2,
+    memo: '임시 로그인 검증용 더미 카드',
+    priority: 'HIGH',
+    jobPostingUrl: 'https://example.com/jobs/frontend-intern',
+    finalResult: null,
+  },
+];
+
+export const TEMP_DEV_TAGS: TagResponse[] = [
+  {
+    id: 1,
+    name: '관심기업',
+    color: '#2563eb',
+  },
+];
+
+export const TEMP_DEV_CALENDAR_EVENTS: CalendarEvent[] = [
+  {
+    id: '2001',
+    applicationId: '1001',
+    category: 'APPLICATION_PROCESS',
+    title: 'OpenAI Korea 과제 제출',
+    startAt: '2026-05-10T04:00:00.000Z',
+    endAt: '2026-05-10T06:00:00.000Z',
+    applicationName: 'OpenAI Korea',
+  },
+  {
+    id: '2002',
+    applicationId: null,
+    category: 'PERSONAL',
+    title: '포트폴리오 정리',
+    startAt: '2026-05-12T10:00:00.000Z',
+    endAt: '2026-05-12T12:00:00.000Z',
+  },
+];
+
+export const TEMP_DEV_PROFILE: UserProfile = {
+  id: 0,
+  oauth2Provider: 'GOOGLE',
+  email: 'dev@chwieolup.local',
+  name: 'Dev User',
+  profileImageUrl: null,
+};
+
+export const TEMP_DEV_RETROSPECTIVE_SUMMARIES: RetrospectiveSummary[] = [
+  {
+    id: '3001',
+    applicationId: '1001',
+    stageId: '101',
+    itemCount: 2,
+    createdAt: '2026-05-08T11:00:00.000Z',
+    updatedAt: '2026-05-08T12:30:00.000Z',
+    company: 'OpenAI Korea',
+    position: 'Frontend Engineer Intern',
+    stageName: '지원 완료',
+    stageColor: '#64748b',
+    isOverall: false,
+  },
+];
+
+export const TEMP_DEV_RETROSPECTIVE_DETAILS: RetrospectiveDetail[] = [
+  {
+    ...TEMP_DEV_RETROSPECTIVE_SUMMARIES[0],
+    items: [
+      {
+        question: '이번 지원에서 잘한 점은 무엇인가요?',
+        answer: '이력서와 포트폴리오를 공고 요구사항에 맞춰 다시 정리했다.',
+      },
+      {
+        question: '다음 지원 전에 보완할 점은 무엇인가요?',
+        answer: '프로젝트 성과를 수치로 더 명확하게 적고, 자기소개 문장을 더 짧게 다듬어야 한다.',
+      },
+    ],
+  },
+];
+
+export const TEMP_DEV_RETROSPECTIVE_TEMPLATES: RetrospectiveTemplate[] = [
+  {
+    id: '4001',
+    name: '기본 회고 템플릿',
+    questions: [
+      '이번 지원에서 잘한 점은 무엇인가요?',
+      '다음 지원 전에 보완할 점은 무엇인가요?',
+      '다음 액션으로 바로 할 일은 무엇인가요?',
+    ],
+  },
+];

--- a/src/lib/api/fetcher.ts
+++ b/src/lib/api/fetcher.ts
@@ -1,4 +1,5 @@
 import { ApiError } from './errors';
+import { isTemporaryDevAuthEnabled } from './dev-auth';
 import { buildRequestUrl, createApiError, parseResponseBody } from './http';
 import { refreshAccessToken, notifyAuthFailure } from './session';
 import { getAccessToken } from './token-store';
@@ -70,6 +71,10 @@ async function executeRequest<T>(
     headers: createHeaders(options),
     credentials,
   });
+
+  if (response.status === 401 && isTemporaryDevAuthEnabled()) {
+    throw await createApiError(response, url);
+  }
 
   if (response.status === 401 && retryOnAuthError && !options.skipAuth && !options._hasRetried) {
     try {

--- a/src/lib/api/session.ts
+++ b/src/lib/api/session.ts
@@ -7,6 +7,7 @@ import {
 import { createApiError, buildRequestUrl, parseResponseBody } from './http';
 import {
   clearAuthSession,
+  markAuthBootstrapped,
   markAuthBootstrapping,
   setAuthSession,
 } from '@/store/auth-store';

--- a/src/lib/api/session.ts
+++ b/src/lib/api/session.ts
@@ -1,8 +1,12 @@
 import { LEGACY_AUTH_COOKIE, LOGIN_ROUTE, REFRESH_ENDPOINT } from './config';
+import {
+  createTemporaryDevSession,
+  disableTemporaryDevAuth,
+  isTemporaryDevAuthEnabled,
+} from './dev-auth';
 import { createApiError, buildRequestUrl, parseResponseBody } from './http';
 import {
   clearAuthSession,
-  markAuthBootstrapped,
   markAuthBootstrapping,
   setAuthSession,
 } from '@/store/auth-store';
@@ -76,6 +80,7 @@ export function onAuthFailure(handler: (() => void) | null) {
 }
 
 export function notifyAuthFailure() {
+  disableTemporaryDevAuth();
   clearAuthSession();
 
   if (authFailureHandler) {
@@ -103,6 +108,11 @@ export async function refreshAccessToken() {
 
 export async function bootstrapSession() {
   markAuthBootstrapping();
+
+  if (isTemporaryDevAuthEnabled()) {
+    setAuthSession(createTemporaryDevSession());
+    return;
+  }
 
   try {
     await refreshAccessToken();


### PR DESCRIPTION
## 관련 이슈

- closes #22 

## 작업 내용

이번 PR에서 작업한 내용을 작성해주세요.

- Gmail OAuth 연동 시 성공/실패 시의 URL 파라미터를 처리했습니다.
- Gmail OAuth 연동 후 다시 설정페이지로 돌아오는 플로우를 추가했습니다.


## 변경 사항

주요 변경 사항을 구체적으로 작성해주세요.

- mailOAuthConnected 가 쿼리 파라미터를 감지해서 연동 성공 여부를 확인- 
- showConnectedNotice 상태로 "Gmail 계정이 성공적으로 연동되었습니다" 알림 배너를 표시합니다.
- 닫기 버튼으로 알림을 닫을 수 있습니다.
- 연동 완료 후 URL에 남아있는 mail_oauth_connected=1 파라미터를 router.replace()로 제거해주었습니다.

## 테스트 내용

어떤 방식으로 테스트했는지 작성해주세요.

- [x] 로컬 테스트 완료
- [x] 주요 기능 정상 동작 확인
- [x] 예외 케이스 확인


## 리뷰 포인트

리뷰어가 중점적으로 보면 좋을 부분을 작성해주세요.

- 눈에보이지 않는 부분이라 따로 사진은 없습니다! 

## 체크리스트

- [x] 제목 규칙을 지켰습니다.  
- [x] 관련 이슈를 연결했습니다.  
- [x] 불필요한 코드나 주석을 제거했습니다.  
- [x] 테스트를 진행했습니다.  
- [x] 문서가 필요한 경우 반영했습니다.
